### PR TITLE
updated numpy.int

### DIFF
--- a/predgpilib/hmm/HMM.py
+++ b/predgpilib/hmm/HMM.py
@@ -10,7 +10,7 @@ except:
 import numpy as NUM
 
 ARRAYFLOAT=NUM.float64
-ARRAYINT=NUM.int
+ARRAYINT=NUM.int32
 
 
 def _getRand(randint,values,names,norm=10000):

--- a/predgpilib/hmm/algo_HMM.py
+++ b/predgpilib/hmm/algo_HMM.py
@@ -56,7 +56,7 @@ import numpy as NUM
 import copy
 
 ARRAYFLOAT=NUM.float64
-ARRAYINT=NUM.int
+ARRAYINT=NUM.int32
 
 
 def for_back_mat(hmm, seq, Scale=None, labels=None):


### PR DESCRIPTION
when working with numpy 1.20 and up numpy.int has been deprecated in favor of numpy.int32